### PR TITLE
Moved _Iterator_type further up in _Sentinel.

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -7311,14 +7311,13 @@ namespace ranges {
             common_type_t<range_difference_t<_Maybe_const<_IteratorConst, _ViewTypes>>...>;
 
         template <bool _IteratorConst>
-        static constexpr bool _Iterator_sentinel_equality_noexcept = noexcept(
-            _Zip::_Evaluate_iterator_sentinel_equality(
-                _Get_iterator_tuple(
-                    _STD declval<const typename zip_view<_ViewTypes...>::template _Iterator<_IteratorConst>&>()),
-                _STD declval<_Sentinel_tuple_type>()));
+        using _Iterator_type = typename zip_view<_ViewTypes...>::template _Iterator<_IteratorConst>;
 
         template <bool _IteratorConst>
-        using _Iterator_type = typename zip_view<_ViewTypes...>::template _Iterator<_IteratorConst>;
+        static constexpr bool _Iterator_sentinel_equality_noexcept = noexcept(
+            _Zip::_Evaluate_iterator_sentinel_equality(
+                _Get_iterator_tuple(_STD declval<const _Iterator_type<_IteratorConst>&>()),
+                _STD declval<_Sentinel_tuple_type>()));
 
     public:
         _Sentinel() noexcept(is_nothrow_default_constructible_v<_Sentinel_tuple_type>) = default;


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
