### PR TITLE
Moved `_Zip_fn` into `std::views` for consistency with `_Meow_fn`.

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -7275,37 +7275,37 @@ namespace ranges {
     template <class... _ViewTypes>
     inline constexpr bool enable_borrowed_range<zip_view<_ViewTypes...>> = (enable_borrowed_range<_ViewTypes> && ...);
 
-    struct _Zip_fn {
-    private:
-        template <class... _Types>
-        static _CONSTEVAL bool _Is_invocation_noexcept() {
-            if constexpr (sizeof...(_Types) == 0) {
-                // NOTE: views::empty<tuple<>> is nothrow copy-constructible.
-                return true;
-            } else {
-                return noexcept(zip_view<views::all_t<_Types>...>(_STD declval<_Types>()...));
-            }
-        }
-
-    public:
-        template <class... _Types>
-            // clang-format off
-        constexpr auto operator()(_Types&&... _Args) const
-            noexcept(_Is_invocation_noexcept<_Types...>())
-            requires (sizeof...(_Types) == 0) || requires {
-                zip_view<views::all_t<_Types>...>(_STD forward<_Types>(_Args)...);
-            }
-        {
-            // clang-format on
-            if constexpr (sizeof...(_Types) == 0) {
-                return empty_view<tuple<>>{};
-            } else {
-                return zip_view<views::all_t<_Types&&>...>(_STD forward<_Types>(_Args)...);
-            }
-        }
-    };
-
     namespace views {
+        struct _Zip_fn {
+        private:
+            template <class... _Types>
+            static _CONSTEVAL bool _Is_invocation_noexcept() {
+                if constexpr (sizeof...(_Types) == 0) {
+                    // NOTE: views::empty<tuple<>> is nothrow copy-constructible.
+                    return true;
+                } else {
+                    return noexcept(zip_view<views::all_t<_Types>...>(_STD declval<_Types>()...));
+                }
+            }
+
+        public:
+            template <class... _Types>
+                // clang-format off
+            constexpr auto operator()(_Types&&... _Args) const
+                noexcept(_Is_invocation_noexcept<_Types...>())
+                requires(sizeof...(_Types) == 0) || requires {
+                    zip_view<views::all_t<_Types>...>(_STD forward<_Types>(_Args)...);
+                }
+            {
+                // clang-format on
+                if constexpr (sizeof...(_Types) == 0) {
+                    return empty_view<tuple<>>{};
+                } else {
+                    return zip_view<views::all_t<_Types&&>...>(_STD forward<_Types>(_Args)...);
+                }
+            }
+        };
+
         _EXPORT_STD inline constexpr _Zip_fn zip{};
     } // namespace views
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
