### PR TITLE
Added most libc++ tests for zip_view.

### DIFF
--- a/stl/inc/ranges
+++ b/stl/inc/ranges
@@ -7416,13 +7416,15 @@ namespace ranges {
         template <bool _IsConst>
         static constexpr bool _Is_end_noexcept = []() {
             if constexpr (!_Zip_is_common<_ViewTypes...>) {
-                return noexcept(_Sentinel<_IsConst>{_Tuple_transform(_RANGES end, _Views)});
+                return noexcept(_Sentinel<_IsConst>{
+                    _Tuple_transform(_RANGES end, _STD declval<_Maybe_const<_IsConst, tuple<_ViewTypes...>>&>())});
             } else if constexpr ((random_access_range<_ViewTypes> && ...)) {
                 // Operations on iter_difference_t values must be noexcept, so we only
                 // need to check the noexcept of begin().
-                return noexcept(_STD declval<_Maybe_const<_IsConst, zip_view<_ViewTypes...>>>().begin());
+                return noexcept(_STD declval<_Maybe_const<_IsConst, zip_view<_ViewTypes...>>&>().begin());
             } else {
-                return noexcept(_Iterator<_IsConst>{_Tuple_transform(_RANGES end, _Views)});
+                return noexcept(_Iterator<_IsConst>{
+                    _Tuple_transform(_RANGES end, _STD declval<_Maybe_const<_IsConst, tuple<_ViewTypes...>>&>())});
             }
         }();
 

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -43,6 +43,9 @@ std/containers/unord/unord.set/insert_and_emplace_allocator_requirements.pass.cp
 # Bogus test believes that copyability of array<T, 0> must be the same as array<T, 1>
 std/containers/sequences/array/array.cons/implicit_copy.pass.cpp FAIL
 
+# Bogus test returns a non-const int& using a const iterator's member variable
+std/ranges/range.adaptors/range.zip/end.pass.cpp FAIL
+
 # libc++ doesn't implement LWG-3648: "format should not print bool with 'c'"
 std/utilities/format/format.functions/vformat_to.locale.pass.cpp FAIL
 std/utilities/format/format.functions/vformat_to.pass.cpp FAIL
@@ -54,6 +57,21 @@ std/strings/basic.string/string.nonmembers/string_op+/allocator_propagation.pass
 
 # libc++ hasn't updated move_iterator for P2520R0
 std/iterators/predef.iterators/move.iterators/move.iterator/types.pass.cpp FAIL
+
+# libc++ doesn't implement LWG-3692: "zip_view::iterator's operator<=> is overconstrained"
+std/ranges/range.adaptors/range.zip/iterator/compare.pass.cpp FAIL
+
+# libc++ is incorrect on the constraints for constructors of zip_view::iterator and zip_view::sentinel
+std/ranges/range.adaptors/range.zip/begin.pass.cpp SKIPPED
+std/ranges/range.adaptors/range.zip/sentinel/ctor.default.pass.cpp SKIPPED
+
+# libc++ has not implemented P2165R4: "Compatibility between tuple, pair, and tuple-like objects"
+# for zip_view
+std/ranges/range.adaptors/range.zip/cpo.pass.cpp FAIL
+std/ranges/range.adaptors/range.zip/ctor.default.pass.cpp FAIL
+std/ranges/range.adaptors/range.zip/iterator/deref.pass.cpp FAIL
+std/ranges/range.adaptors/range.zip/iterator/member_types.compile.pass.cpp FAIL
+std/ranges/range.adaptors/range.zip/iterator/subscript.pass.cpp FAIL
 
 
 # *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***
@@ -192,32 +210,6 @@ std/utilities/tuple/tuple.tuple/tuple.cnstr/recursion_depth.pass.cpp SKIPPED
 # P2321R2 zip
 std/language.support/support.limits/support.limits.general/tuple.version.compile.pass.cpp FAIL
 std/language.support/support.limits/support.limits.general/utility.version.compile.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/begin.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/borrowing.compile.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/cpo.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/ctad.compile.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/ctor.default.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/ctor.views.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/end.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/general.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/iterator/arithmetic.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/iterator/compare.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/iterator/ctor.default.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/iterator/ctor.other.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/iterator/decrement.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/iterator/deref.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/iterator/increment.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/iterator/iter_move.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/iterator/iter_swap.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/iterator/member_types.compile.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/iterator/singular.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/iterator/subscript.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/range.concept.compile.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/sentinel/ctor.default.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/sentinel/ctor.other.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/sentinel/eq.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/sentinel/minus.pass.cpp FAIL
-std/ranges/range.adaptors/range.zip/size.pass.cpp FAIL
 
 # P2255R2 "Type Traits To Detect References Binding To Temporaries"
 std/language.support/support.limits/support.limits.general/type_traits.version.compile.pass.cpp FAIL


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
